### PR TITLE
Use multibyte aware substring or json_encode can break

### DIFF
--- a/Gateway/Command/SveaCommand.php
+++ b/Gateway/Command/SveaCommand.php
@@ -308,7 +308,7 @@ class SveaCommand implements
 
             if ($item->getDiscountAmount()) {
                 $prefixedSku = sprintf($prefix.'discount-%s',  trim($orderItem->getQuoteItemId()));
-                $sku         = substr($prefixedSku, 0, 40);
+                $sku         = mb_substr($prefixedSku, 0, 40);
                 $items[]     = [
                     'sku'         => $sku,
                     'qty'         => 1,

--- a/Model/Api/BuildOrder.php
+++ b/Model/Api/BuildOrder.php
@@ -290,13 +290,13 @@ class BuildOrder
                 ->setVatPercent((int)round($item->getTaxPercent()))
                 ->setQuantity((float)round($qty, 2))
                 ->setArticleNumber($prefix . $item->getSku())
-                ->setName((string)substr($item->getName(), 0, 40))
+                ->setName(mb_substr($item->getName(), 0, 40))
                 ->setTemporaryReference((string)$item->getId());
             $buildOrder->addOrderRow($orderRowItem);
 
             if ((float)$item->getDiscountAmount()) {
                 $itemRowDiscount = WebPayItem::fixedDiscount()
-                    ->setName(substr(sprintf('discount-%s', $prefix . $item->getId()), 0, 40))
+                    ->setName(mb_substr(sprintf('discount-%s', $prefix . $item->getId()), 0, 40))
                     ->setVatPercent((int)round($item->getTaxPercent()))
                     ->setAmountIncVat((float)$item->getDiscountAmount());
 
@@ -571,7 +571,7 @@ class BuildOrder
         //Add shipping to SveaOrder.
         $vatPercent    = 0;
         $shippingTitle = ($methodTitle)
-            ? substr($methodTitle, 0, 40)
+            ? mb_substr($methodTitle, 0, 40)
             : __('Shipping');
         $shippingPrice = ($didNotLoadFromQuote && isset($fallbackPrice))
             ? $fallbackPrice
@@ -696,7 +696,7 @@ class BuildOrder
         foreach ($totals as $totalRow) {
             $amount = round($totalRow->getValue(), 2);
             $title  = ($totalRow->getTitle())
-                ? substr($totalRow->getTitle(), 0, 40)
+                ? mb_substr($totalRow->getTitle(), 0, 40)
                 : __('fee');
 
             $fee = WebPayItem::invoiceFee()


### PR DESCRIPTION
Good day!

We came across a problem that checkout doesn't open when cart contains some specific products. It turned out that with Norwegian symbols in product name substr() function can cut in half of the symbol, resulting in corrupt string.
json_encode, in turn, fails to encode such a value https://prnt.sc/i1q7rm

My suggestion is to use mb_substr in stead. Please review

Thanks :)